### PR TITLE
Add `#[repr(C)]` as a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ authors = ["Tejas Mehta <tmthecoder@gmail.com>"]
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = []
+ffi = []
+
 [dependencies]
 hmac = "0.12.0"
 sha-1 = "0.10.0"

--- a/src/hotp.rs
+++ b/src/hotp.rs
@@ -18,6 +18,7 @@ use base32::Alphabet;
 /// [RFC4226]: https://datatracker.ietf.org/doc/html/rfc4226
 
 #[derive(Debug, Clone, Hash)]
+#[cfg_attr(feature = "ffi", repr(C))]
 pub struct HOTP {
     /// The secret key used in the HMAC process.
     ///

--- a/src/totp.rs
+++ b/src/totp.rs
@@ -17,6 +17,7 @@ use base32::Alphabet;
 /// [RFC6238]: https://datatracker.ietf.org/doc/html/rfc6238
 
 #[derive(Debug, Clone, Hash)]
+#[cfg_attr(feature = "ffi", repr(C))]
 pub struct TOTP {
     /// The secret key used in the HMAC process.
     ///

--- a/src/util.rs
+++ b/src/util.rs
@@ -15,6 +15,7 @@ use sha2::{Sha256, Sha512};
 /// [RFC6238]: https://datatracker.ietf.org/doc/html/rfc6238
 
 #[derive(Debug, Copy, Clone, Hash)]
+#[cfg_attr(feature = "ffi", repr(C))]
 pub enum MacDigest {
     SHA1,
     SHA256,


### PR DESCRIPTION
Adds the `#[repr(C)]` attribute for each public struct for those using the crate with the "ffi" feature enabled