### PR TITLE
Add in the `time_until_refresh` method to the TOTP struct

### DIFF
--- a/src/totp.rs
+++ b/src/totp.rs
@@ -168,10 +168,7 @@ impl TOTP {
     /// in seconds.
     pub fn time_until_refresh_with_start(&self, time: u64, time_start: u64) -> u64 {
         let time_until = (time - time_start) % self.period;
-        if time_until == 0 {
-            return self.period;
-        }
-        time_until
+        if time_until == 0 { self.period } else { time_until }
     }
 }
 

--- a/src/totp.rs
+++ b/src/totp.rs
@@ -167,7 +167,11 @@ impl TOTP {
     /// specified start time in case an offset is desired. Both values must be
     /// in seconds.
     pub fn time_until_refresh_with_start(&self, time: u64, time_start: u64) -> u64 {
-        (time - time_start) % period
+        let time_until = (time - time_start) % self.period;
+        if time_until == 0 {
+            return self.period;
+        }
+        time_until
     }
 }
 

--- a/src/totp.rs
+++ b/src/totp.rs
@@ -149,6 +149,28 @@ impl TOTP {
     }
 }
 
+/// All helper methods for totp generation
+impl TOTP {
+
+    /// Returns the time in seconds until an OTP refresh is needed.
+    ///
+    /// Just like the corresponding [`TOTP::get_otp`] method, this method
+    /// takes the current system time in seconds.
+    pub fn time_until_refresh(&self, time: u64) -> u64 {
+        self.time_until_refresh_with_start(time, 0)
+    }
+
+    /// Returns the time in seconds until an OTP refresh is needed.
+    ///
+    /// Just like the corresponding [`TOTP::get_otp_with_custom_time_start`]
+    /// method, this method takes the current time in seconds along with a
+    /// specified start time in case an offset is desired. Both values must be
+    /// in seconds.
+    pub fn time_until_refresh_with_start(&self, time: u64, time_start: u64) -> u64 {
+        (time - time_start) % period
+    }
+}
+
 /// All otp generation methods for the [`TOTP`] struct.
 impl TOTP {
     /// Generates and returns the TOTP value for the specified time.

--- a/tests/totp.rs
+++ b/tests/totp.rs
@@ -215,3 +215,28 @@ fn rfc_test_6_sha512() {
         47863826
     )
 }
+
+// Tests to check the time_until_refresh methods.
+#[test]
+fn test_time_until() {
+    let totp = TOTP::default_from_base32("SecretKey");
+    assert_eq!(totp.time_until_refresh(15), 15);
+}
+
+#[test]
+fn test_time_until_at_edge() {
+    let totp = TOTP::default_from_base32("SecretKey");
+    assert_eq!(totp.time_until_refresh(30), 30)
+}
+
+#[test]
+fn test_time_until_with_start() {
+    let totp = TOTP::default_from_base32("SecretKey");
+    assert_eq!(totp.time_until_refresh_with_start(30, 15), 15)
+}
+
+#[test]
+fn test_time_until_with_start_at_edge() {
+    let totp = TOTP::default_from_base32("SecretKey");
+    assert_eq!(totp.time_until_refresh_with_start(45, 15), 30)
+}


### PR DESCRIPTION
Adds in the `time_until_refresh` method to the TOTP struct, along with a `time_until_refresh_with_start` method if a start offset is desired. 

This is the second part of the requested functionality from #4 